### PR TITLE
Enable SSO cookie support in gateway

### DIFF
--- a/blade-auth/src/main/java/org/springblade/auth/controller/AuthController.java
+++ b/blade-auth/src/main/java/org/springblade/auth/controller/AuthController.java
@@ -27,16 +27,20 @@ import org.springblade.auth.utils.TokenUtil;
 import org.springblade.common.cache.CacheNames;
 import org.springblade.core.redis.cache.BladeRedis;
 import org.springblade.core.secure.AuthInfo;
+import org.springblade.core.launch.constant.TokenConstant;
 import org.springblade.core.tool.api.R;
 import org.springblade.core.tool.support.Kv;
 import org.springblade.core.tool.utils.Func;
 import org.springblade.core.tool.utils.WebUtil;
 import org.springblade.system.user.entity.UserInfo;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -50,15 +54,22 @@ import java.util.concurrent.TimeUnit;
 @Tag(name = "用户授权认证", description = "授权接口")
 public class AuthController {
 
-	private BladeRedis bladeRedis;
+        private BladeRedis bladeRedis;
 
-	@PostMapping("token")
-	@Operation(summary = "获取认证token", description = "传入租户ID:tenantId,账号:account,密码:password")
-	public R<AuthInfo> token(@Parameter(description = "授权类型", required = true) @RequestParam(defaultValue = "password", required = false) String grantType,
-							 @Parameter(description = "刷新令牌") @RequestParam(required = false) String refreshToken,
-							 @Parameter(description = "租户ID", required = true) @RequestParam(defaultValue = "000000", required = false) String tenantId,
-							 @Parameter(description = "账号") @RequestParam(required = false) String account,
-							 @Parameter(description = "密码") @RequestParam(required = false) String password) {
+        @Value("${sso.cookie-name:Blade-Auth}")
+        private String cookieName;
+
+        @Value("${sso.cookie-domain:}")
+        private String cookieDomain;
+
+        @PostMapping("token")
+        @Operation(summary = "获取认证token", description = "传入租户ID:tenantId,账号:account,密码:password")
+        public R<AuthInfo> token(@Parameter(description = "授权类型", required = true) @RequestParam(defaultValue = "password", required = false) String grantType,
+                                                         @Parameter(description = "刷新令牌") @RequestParam(required = false) String refreshToken,
+                                                         @Parameter(description = "租户ID", required = true) @RequestParam(defaultValue = "000000", required = false) String tenantId,
+                                                         @Parameter(description = "账号") @RequestParam(required = false) String account,
+                                                         @Parameter(description = "密码") @RequestParam(required = false) String password,
+                                                         HttpServletResponse response) {
 
 		String userType = Func.toStr(WebUtil.getRequest().getHeader(TokenUtil.USER_TYPE_HEADER_KEY), TokenUtil.DEFAULT_USER_TYPE);
 
@@ -73,12 +84,21 @@ public class AuthController {
 		ITokenGranter granter = TokenGranterBuilder.getGranter(grantType);
 		UserInfo userInfo = granter.grant(tokenParameter);
 
-		if (userInfo == null || userInfo.getUser() == null || userInfo.getUser().getId() == null) {
-			return R.fail(TokenUtil.USER_NOT_FOUND);
-		}
+                if (userInfo == null || userInfo.getUser() == null || userInfo.getUser().getId() == null) {
+                        return R.fail(TokenUtil.USER_NOT_FOUND);
+                }
 
-		return R.data(TokenUtil.createAuthInfo(userInfo));
-	}
+                AuthInfo authInfo = TokenUtil.createAuthInfo(userInfo);
+                Cookie cookie = new Cookie(cookieName, TokenConstant.BEARER + authInfo.getAccessToken());
+                cookie.setPath("/");
+                if (org.springframework.util.StringUtils.hasText(cookieDomain)) {
+                        cookie.setDomain(cookieDomain);
+                }
+                cookie.setHttpOnly(true);
+                response.addCookie(cookie);
+
+                return R.data(authInfo);
+        }
 
 	@GetMapping("/captcha")
 	@Operation(summary = "获取验证码")

--- a/blade-auth/src/main/resources/application-dev.yml
+++ b/blade-auth/src/main/resources/application-dev.yml
@@ -14,3 +14,6 @@ spring:
 social:
   enabled: true
   domain: http://127.0.0.1:1888
+sso:
+  cookie-name: Blade-Auth
+  cookie-domain: localhost

--- a/blade-auth/src/main/resources/application-prod.yml
+++ b/blade-auth/src/main/resources/application-prod.yml
@@ -14,3 +14,6 @@ spring:
 social:
   enabled: true
   domain: http://127.0.0.1:1888
+sso:
+  cookie-name: Blade-Auth
+  cookie-domain: localhost

--- a/blade-auth/src/main/resources/application.yml
+++ b/blade-auth/src/main/resources/application.yml
@@ -21,3 +21,6 @@ social:
       client-id: 233************
       client-secret: 233************************************
       redirect-uri: ${social.domain}/oauth/redirect/dingtalk
+sso:
+  cookie-name: Blade-Auth
+  cookie-domain: localhost

--- a/blade-gateway/src/main/java/org/springblade/gateway/filter/AuthFilter.java
+++ b/blade-gateway/src/main/java/org/springblade/gateway/filter/AuthFilter.java
@@ -35,6 +35,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.stereotype.Component;
 import org.springframework.util.AntPathMatcher;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -52,10 +53,12 @@ import static org.springblade.gateway.utils.JwtCrypto.BLADE_CRYPTO_AES_KEY;
 @Component
 @AllArgsConstructor
 public class AuthFilter implements GlobalFilter, Ordered {
-	private final AuthProperties authProperties;
-	private final ObjectMapper objectMapper;
-	private final BladeProperties bladeProperties;
-	private final AntPathMatcher antPathMatcher = new AntPathMatcher();
+        private final AuthProperties authProperties;
+        private final ObjectMapper objectMapper;
+        private final BladeProperties bladeProperties;
+        @Value("${sso.cookie-name:Blade-Auth}")
+        private String cookieName;
+        private final AntPathMatcher antPathMatcher = new AntPathMatcher();
 
 	@Override
 	public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
@@ -64,13 +67,17 @@ public class AuthFilter implements GlobalFilter, Ordered {
 			return chain.filter(exchange);
 		}
 		ServerHttpResponse resp = exchange.getResponse();
-		String headerToken = exchange.getRequest().getHeaders().getFirst(AuthProvider.AUTH_KEY);
-		String paramToken = exchange.getRequest().getQueryParams().getFirst(AuthProvider.AUTH_KEY);
-		if (StringUtils.isBlank(headerToken) && StringUtils.isBlank(paramToken)) {
-			return unAuth(resp, "缺失令牌,鉴权失败");
-		}
-		String auth = StringUtils.isBlank(headerToken) ? paramToken : headerToken;
-		String token = JwtUtil.getToken(auth);
+                String headerToken = exchange.getRequest().getHeaders().getFirst(AuthProvider.AUTH_KEY);
+                String paramToken = exchange.getRequest().getQueryParams().getFirst(AuthProvider.AUTH_KEY);
+                String cookieToken = null;
+                if (exchange.getRequest().getCookies().containsKey(cookieName)) {
+                        cookieToken = exchange.getRequest().getCookies().getFirst(cookieName).getValue();
+                }
+                if (StringUtils.isBlank(headerToken) && StringUtils.isBlank(paramToken) && StringUtils.isBlank(cookieToken)) {
+                        return unAuth(resp, "缺失令牌,鉴权失败");
+                }
+                String auth = StringUtils.isBlank(headerToken) ? (StringUtils.isBlank(paramToken) ? cookieToken : paramToken) : headerToken;
+                String token = JwtUtil.getToken(auth);
 		//校验 加密Token 合法性
 		if (JwtUtil.isCrypto(auth)) {
 			token = JwtCrypto.decryptToString(token, bladeProperties.getEnvironment().getProperty(BLADE_CRYPTO_AES_KEY));

--- a/blade-gateway/src/main/resources/application-dev.yml
+++ b/blade-gateway/src/main/resources/application-dev.yml
@@ -9,3 +9,6 @@ blade:
     prior-ip-pattern:
       - 192.168.0.*
       - 127.0.0.1
+
+sso:
+  cookie-name: Blade-Auth

--- a/blade-gateway/src/main/resources/application.yml
+++ b/blade-gateway/src/main/resources/application.yml
@@ -14,3 +14,6 @@ knife4j:
         - blade-admin
         - blade-gateway
         - blade-log
+
+sso:
+  cookie-name: Blade-Auth


### PR DESCRIPTION
## Summary
- inject the SSO cookie name into `AuthFilter`
- read the token from that configured cookie
- configure `sso.cookie-name` in gateway `application.yml` files

## Testing
- `mvn -q -DskipTests install` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_683bf312e270832dbf96e80af1c50798